### PR TITLE
mysql decimal columns parsed to c# decimal type

### DIFF
--- a/Src/Simple.Data.Mysql.Test/DecimalTests.cs
+++ b/Src/Simple.Data.Mysql.Test/DecimalTests.cs
@@ -1,0 +1,23 @@
+using System;
+using NUnit.Framework;
+
+namespace Simple.Data.Mysql.Test
+{
+    [TestFixture]
+    public class DecimalTests
+    {
+        private static readonly string ConnectionString =
+            "server=localhost;user=root;database=simpledatatest;";
+
+        [Test]
+        public void CorrectDecimalValue()
+        {
+            var db = Database.OpenConnection(ConnectionString);
+            var price = Convert.ToDecimal(4.75);
+            db.Items.Insert(Name: "Table", Price: price);
+            var tableItem = db.Items.FindBy(Name: "Table");
+            Assert.True(tableItem.Price == price);
+            db.Items.Delete(ItemId: tableItem.ItemId);  
+        }
+    }
+}

--- a/Src/Simple.Data.Mysql.Test/MySqlColumnInfoTest.cs
+++ b/Src/Simple.Data.Mysql.Test/MySqlColumnInfoTest.cs
@@ -1,0 +1,30 @@
+using System.Data;
+using NUnit.Framework;
+
+namespace Simple.Data.Mysql.Test
+{
+    [TestFixture]
+    public class MySqlColumnInfoTest
+    {
+        [Test]
+        public void DecimalColumnWithCapacityAndPrecisionParsedToDecimal()
+        {
+            var columnInfo = MysqlColumnInfo.CreateColumnInfo("Price", "Price", "decimal(10,2)", "price");
+            Assert.True(columnInfo.DbType == DbType.Decimal);
+            Assert.True(columnInfo.Capacity == 10);
+        }
+
+        public void DecimalColumnWithoutCapacityParsedToDecimal()
+        {
+            var columnInfo = MysqlColumnInfo.CreateColumnInfo("Price", "Price", "decimal", "price");
+            Assert.True(columnInfo.DbType == DbType.Decimal);
+        }
+        public void DecimalColumnWithCapacityWithoutPrecisionParsedToDecimal()
+        {
+            var columnInfo = MysqlColumnInfo.CreateColumnInfo("Price", "Price", "decimal(10)", "price");
+            Assert.True(columnInfo.DbType == DbType.Decimal);
+            Assert.True(columnInfo.Capacity == 10);
+        }
+        
+    }
+}

--- a/Src/Simple.Data.Mysql.Test/Simple.Data.Mysql.Test.csproj
+++ b/Src/Simple.Data.Mysql.Test/Simple.Data.Mysql.Test.csproj
@@ -93,9 +93,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DecimalTests.cs" />
     <Compile Include="FindTests.cs" />
     <Compile Include="ForeignKeyTests.cs" />
     <Compile Include="InsertTests.cs" />
+    <Compile Include="MySqlColumnInfoTest.cs" />
     <Compile Include="MysqlConnectorHelperTest.cs" />
     <Compile Include="OrderDetailTests.cs" />
     <Compile Include="SchemaDataProviderTests\40SchemaDataProviderTests.cs" />

--- a/Src/Simple.Data.Mysql/MysqlColumnInfo.cs
+++ b/Src/Simple.Data.Mysql/MysqlColumnInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Simple.Data.Mysql
@@ -97,14 +98,25 @@ namespace Simple.Data.Mysql
             //typename(capacity) and plain typename
             //capture group 1 captures typename
             //capture group 2 captures capacity if present
-            var regex = new Regex(@"^([^(]+)(?:\((\d+)\))?$");
+            var regex = new Regex(@"^([^(]+)(?:\(([0-9]+||[0-9]+,[0-9]+)\))?$");
             var match = regex.Match(typeColumnValue);
 
             if (match.Groups[1].Success)
                 type = GetDbType(match.Groups[1].Value);
 
             if (match.Groups[2].Success)
-                capacity = int.Parse(match.Groups[2].Value);
+            {
+                var capacitySplits = match.Groups[2].Value.Split(',');
+                if (capacitySplits.Any())
+                {
+                    capacity = int.Parse(capacitySplits.First());
+                }
+                else
+                {
+                    capacity = int.Parse(match.Groups[2].Value);
+                }
+            }
+
 
         }
     }


### PR DESCRIPTION
I have solved a problem saving decimal columns. They were losing the decimal points.
The regular expression used to parse the database columns data types to c# types was not correct when the mysql column had especified precison.
