### PR TITLE
Fixing way in which absolute path to assembly location is obtained.

### DIFF
--- a/Src/Simple.Data.Mysql/MysqlConnectorHelper.cs
+++ b/Src/Simple.Data.Mysql/MysqlConnectorHelper.cs
@@ -51,7 +51,7 @@ namespace Simple.Data.Mysql
 		{
 			get
 			{
-				string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+				string codeBase = Assembly.GetAssembly(typeof(MysqlConnectorHelper)).CodeBase;
 				UriBuilder uri = new UriBuilder(codeBase);
 				string path = Uri.UnescapeDataString(uri.Path);
 				return Path.GetDirectoryName(path);


### PR DESCRIPTION
As it is said in:
http://msdn.microsoft.com/en-us/library/system.reflection.assembly.codebase(v=vs.110).aspx#Remarks

To get the absolute path it is better to use Location. 
Which is cross-plataform safe.
