### PR TITLE
Incorporate assembly dir location for mono, unc and normal file paths

### DIFF
--- a/Src/Simple.Data.Mysql.sln
+++ b/Src/Simple.Data.Mysql.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simple.Data.Mysql", "Simple.Data.Mysql\Simple.Data.Mysql.csproj", "{6BB6D48E-E2AB-4AF7-8FE3-10A3AACE3FC7}"
 EndProject


### PR DESCRIPTION
This still needs checking out ideally, but I think we are good to go

```
public static bool IsRunningOnMono()
{
  //This ideally needs confirming that this is the proper way to identify mono
  return Type.GetType("Mono.Runtime") != null;
}
```
