### PR TITLE
adding data type binary ->{"binary", DbType.Binary}

### DIFF
--- a/Src/Simple.Data.Mysql/MysqlColumnInfo.cs
+++ b/Src/Simple.Data.Mysql/MysqlColumnInfo.cs
@@ -42,7 +42,8 @@ namespace Simple.Data.Mysql
                                                                             {"time", DbType.Time},
                                                                             {"year", DbType.Int16},
                                                                             {"enum", DbType.String},
-                                                                            {"set", DbType.String}
+                                                                            {"set", DbType.String},
+                                                                            {"binary", DbType.Binary} 
                                                                         };
 
         public string Name { get; private set; }


### PR DESCRIPTION
Adding missing datatype of "binary" to MysqlColumnInfo DbTypes  Dictionary
